### PR TITLE
Install APCu stable version

### DIFF
--- a/provision/bootstrap.sh
+++ b/provision/bootstrap.sh
@@ -12,7 +12,7 @@ pear config-set php_ini /etc/php5/apache2/php.ini
 
 # Install packages
 echo "Installing APCu..."
-printf "no\nno" | pecl install APCu-beta
+printf "no\nno" | pecl install APCu
 
 # Run codebase specific setup scripts
 sh /var/www/scripts/setup.sh || true


### PR DESCRIPTION
APCu is now shipped on two channels, beta and stable.

The beta version is for PHP 7, the stable version PHP 5.3+.
