### PR TITLE
Force LF line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force LF line endings on Windows.
+* text eol=lf


### PR DESCRIPTION
Forces "line feed" only line endings on Windows so VM scripts don't crash when they see a "carriage return".