### PR TITLE
Make start_mailcatcher.sh edit php.ini

### DIFF
--- a/provision/start_mailcatcher.sh
+++ b/provision/start_mailcatcher.sh
@@ -5,5 +5,10 @@ mailcatcher --http-ip=0.0.0.0
 
 echo "Connect to 192.168.48.48:1080 in the browser"
 
+sudo sh -c 'if ! grep -q "sendmail_path=/usr/bin/env" "/etc/php/7.0/apache2/php.ini"; then
+  echo "sendmail_path=/usr/bin/env /home/vagrant/.rbenv/shims/catchmail" >> /etc/php/7.0/apache2/php.ini
+  service apache2 restart
+fi'
+
 # Done
 exit


### PR DESCRIPTION
This is pretty much a hack... It will set php.ini's "sendmail_path" to "catchmail" the first time ./start_mailcatcher.sh is executed.

Because the VM (as far as I understand the deployment system) will never be intended to send email, this could be set in setup.sh and mailcatcher could be started on system up. So all email is always intercepted. I think this would be a better solution then the hack I put together here, let me know.