### PR TITLE
Use newer version of nodejs

### DIFF
--- a/provision/userbootstrap.sh
+++ b/provision/userbootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # This is the bootstrapping script that provisions the vagrant user
 
-NODEJS_VERSION="v9"
+NODEJS_VERSION="v12"
 
 echo "\nRunning userbootstrap.sh as unprivileged user \n"
 


### PR DESCRIPTION
When `make`ing:
```
/vagrant/www/node_modules/eslint/bin/eslint.js:93
        } catch {
                ^
SyntaxError: Unexpected token {
```

The latest ESLint version is too new for the nodejs version 9 present on the Vagrant box, so let's update it to 12; it doesn't seem to break anything else.